### PR TITLE
Linter hotfix for false positive on typed args

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -20,5 +20,13 @@
     ],
     "rules": {
         "no-var": "error"
-    }
+    },
+    "overrides": [
+        {
+          "files": ["*.ts"],
+          "rules": {
+            "@typescript-eslint/no-unused-vars": [2, { "args": "none" }]
+          }
+        }
+      ]
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -25,5 +25,13 @@
     ],
     "rules": {
         "no-var": "error"
-    }
+    },
+    "overrides": [
+        {
+          "files": ["*.ts", "*.tsx"],
+          "rules": {
+            "@typescript-eslint/no-unused-vars": [2, { "args": "none" }]
+          }
+        }
+      ]
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "extends": [
         "standard",
-        "plugin:react/recommended"
+        "plugin:react/recommended",
+        "plugin:jsx-a11y/recommended"
     ],
     "globals": {
         "Atomics": "readonly",
@@ -21,7 +22,8 @@
     },
     "plugins": [
         "react",
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "jsx-a11y"
     ],
     "rules": {
         "no-var": "error"

--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "eslint": "^6.3.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.14.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3677,7 +3677,7 @@ eslint-plugin-import@2.18.2, eslint-plugin-import@^2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jsx-a11y@6.2.3:
+eslint-plugin-jsx-a11y@6.2.3, eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
   integrity sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==


### PR DESCRIPTION
When utilzing your types for function arguments only, @typescript-eslint falls on its face. It tries to tell you that you are not using your Typescript types when you definitely are.

Also added accessibility related config.