### PR TITLE
Added linting config to make sure hooks are used properly

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -23,10 +23,13 @@
     "plugins": [
         "react",
         "@typescript-eslint",
-        "jsx-a11y"
+        "jsx-a11y",
+        "react-hooks"
     ],
     "rules": {
-        "no-var": "error"
+        "no-var": "error",
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "warn"
     },
     "overrides": [
         {

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "eslint-plugin-standard": "^4.0.1"
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3714,6 +3714,11 @@ eslint-plugin-react-hooks@^1.6.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
+  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
+
 eslint-plugin-react@7.14.3, eslint-plugin-react@^7.14.3:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"


### PR DESCRIPTION
This extremely popular linting config will save us bugs by making sure we provide the necessary dependencies when using hooks. 

It has two features: 
1. Checking hooks dependencies array for correctness (will autofix for you)
2. Will make sure you don't break the rules of hooks (ex. conditionally rendering hooks)