### PR TITLE
Updated React Scripts due to cryptic build error inside of docker

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "@types/react-dom": "16.9.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "react-scripts": "3.1.1",
+    "react-scripts": "^3.1.2",
     "styled-components": "^4.3.2",
     "typescript": "3.6.2"
   },


### PR DESCRIPTION
Resolves the cryptic `Cannot find rule definition for @typescript-eslint/consistent-type-assertions` red herring error.